### PR TITLE
Address readability issues of some background highlight properties

### DIFF
--- a/catppuccin-frappe/theme.css
+++ b/catppuccin-frappe/theme.css
@@ -638,7 +638,6 @@ navband_t
     qproperty-extern : ${color-pink};
     qproperty-lumina-function : ${color-green};
 
-    /* same colors as above but lightness turned up by 5% */
     qproperty-hl-lib-function : rgb(172, 217, 226);
     qproperty-hl-function : rgb(242, 175, 141);
     qproperty-hl-code : rgb(247, 231, 227);
@@ -665,7 +664,6 @@ navband_t[os-dark-theme="true"]
     qproperty-extern : ${color-pink};
     qproperty-lumina-function : ${color-green};
 
-    /* same colors as above but lightness turned up by 5% */
     qproperty-hl-lib-function : rgb(172, 217, 226);
     qproperty-hl-function : rgb(242, 175, 141);
     qproperty-hl-code : rgb(247, 231, 227);
@@ -737,7 +735,7 @@ TextEdit {
 /* main color scheme */
 CustomIDAMemo {
   /* current line background overlay */
-  qproperty-line-bgovl-current-line: rgba(220, 138, 120, 0.25); /*rosewater*/
+  qproperty-line-bgovl-current-line: rgba(220, 138, 120, 0.1); /*rosewater*/
   qproperty-line-fg-default: ${color-overlay2};
   qproperty-line-fg-regular-comment: ${color-pink};
   qproperty-line-fg-repeatable-comment: ${color-mauve};
@@ -788,8 +786,8 @@ CustomIDAMemo {
   qproperty-line-pfx-lumina: ${color-green};
   /*qproperty-line-pfx-current-item: ${color-sapphire};*/
   qproperty-line-pfx-current-line: ${color-peach};
-  qproperty-line-bg-bpt-enabled: ${color-teal};
-  qproperty-line-bg-bpt-disabled: ${color-text};
+  qproperty-line-bg-bpt-enabled: rgba(231, 130, 132, 0.3); /*red*/
+  qproperty-line-bg-bpt-disabled: rgba(166, 209, 137, 0.3); /*green*/
   qproperty-line-bg-bpt-unavailable: ${color-overlay0};
   qproperty-graph-bg-top: ${color-crust};
   qproperty-graph-bg-bottom: ${color-crust};
@@ -808,7 +806,7 @@ CustomIDAMemo {
   qproperty-graph-edge-current: ${color-text};
   qproperty-line-fg-patched-bytes: ${color-mauve};
   qproperty-line-fg-unsaved-changes: ${color-teal};
-  qproperty-line-bg-highlight: rgba(220, 138, 120, 0.5); /*rosewater*/
+  qproperty-line-bg-highlight: rgba(234, 153, 156, 0.19); /*rosewater*/
   qproperty-line-bg-hint: ${color-mauve};
 }
 CustomIDAMemo[debugging="true"],

--- a/catppuccin-latte/theme.css
+++ b/catppuccin-latte/theme.css
@@ -638,7 +638,6 @@ navband_t
     qproperty-extern : ${color-pink};
     qproperty-lumina-function : ${color-green};
 
-    /* same colors as above but lightness turned up by 5% */
     qproperty-hl-lib-function : rgb(8, 182, 251);
     qproperty-hl-function : rgb(254, 116, 36);
     qproperty-hl-code : rgb(225, 156, 140);
@@ -665,7 +664,6 @@ navband_t[os-dark-theme="true"]
     qproperty-extern : ${color-pink};
     qproperty-lumina-function : ${color-green};
     
-    /* same colors as above but lightness turned up by 5% */
     qproperty-hl-lib-function : rgb(8, 182, 251);
     qproperty-hl-function : rgb(254, 116, 36);
     qproperty-hl-code : rgb(225, 156, 140);
@@ -738,7 +736,7 @@ TextEdit {
 /* main color scheme */
 CustomIDAMemo {
   /* current line background overlay */
-  qproperty-line-bgovl-current-line: rgba(220, 138, 120, 0.25); /*rosewater*/
+  qproperty-line-bgovl-current-line: rgba(220, 138, 120, 0.1); /*rosewater*/
   qproperty-line-fg-default: ${color-overlay2};
   qproperty-line-fg-regular-comment: ${color-pink};
   qproperty-line-fg-repeatable-comment: ${color-mauve};
@@ -789,8 +787,8 @@ CustomIDAMemo {
   qproperty-line-pfx-lumina: ${color-green};
   /*qproperty-line-pfx-current-item: ${color-sapphire};*/
   qproperty-line-pfx-current-line: ${color-peach};
-  qproperty-line-bg-bpt-enabled: ${color-teal};
-  qproperty-line-bg-bpt-disabled: ${color-text};
+  qproperty-line-bg-bpt-enabled: rgba(210, 15, 57, 0.3); /*red*/
+  qproperty-line-bg-bpt-disabled: rgb(64, 160, 43, 0.3); /*green*/
   qproperty-line-bg-bpt-unavailable: ${color-overlay0};
   qproperty-graph-bg-top: ${color-crust};
   qproperty-graph-bg-bottom: ${color-crust};
@@ -809,7 +807,7 @@ CustomIDAMemo {
   qproperty-graph-edge-current: ${color-text};
   qproperty-line-fg-patched-bytes: ${color-mauve};
   qproperty-line-fg-unsaved-changes: ${color-teal};
-  qproperty-line-bg-highlight: rgba(220, 138, 120, 0.5); /*rosewater*/
+  qproperty-line-bg-highlight: rgba(220, 138, 120, 0.19); /*rosewater*/
   qproperty-line-bg-hint: ${color-mauve};
 }
 CustomIDAMemo[debugging="true"],

--- a/catppuccin-macchiato/theme.css
+++ b/catppuccin-macchiato/theme.css
@@ -638,7 +638,6 @@ navband_t
     qproperty-extern : ${color-pink};
     qproperty-lumina-function : ${color-green};
 
-    /* same colors as above but lightness turned up by 5% */
     qproperty-hl-lib-function : rgb(165, 222, 232);
     qproperty-hl-function : rgb(247, 185, 151);
     qproperty-hl-code : rgb(249, 237, 234);
@@ -665,7 +664,6 @@ navband_t[os-dark-theme="true"]
     qproperty-extern : ${color-pink};
     qproperty-lumina-function : ${color-green};
 
-    /* same colors as above but lightness turned up by 5% */
     qproperty-hl-lib-function : rgb(165, 222, 232);
     qproperty-hl-function : rgb(247, 185, 151);
     qproperty-hl-code : rgb(249, 237, 234);
@@ -737,7 +735,7 @@ TextEdit {
 /* main color scheme */
 CustomIDAMemo {
   /* current line background overlay */
-  qproperty-line-bgovl-current-line: rgba(220, 138, 120, 0.25); /*rosewater*/
+  qproperty-line-bgovl-current-line: rgba(220, 138, 120, 0.1); /*rosewater*/
   qproperty-line-fg-default: ${color-overlay2};
   qproperty-line-fg-regular-comment: ${color-pink};
   qproperty-line-fg-repeatable-comment: ${color-mauve};
@@ -788,8 +786,8 @@ CustomIDAMemo {
   qproperty-line-pfx-lumina: ${color-green};
   /*qproperty-line-pfx-current-item: ${color-sapphire};*/
   qproperty-line-pfx-current-line: ${color-peach};
-  qproperty-line-bg-bpt-enabled: ${color-teal};
-  qproperty-line-bg-bpt-disabled: ${color-text};
+  qproperty-line-bg-bpt-enabled: rgba(237, 135, 150, 0.3); /*red*/
+  qproperty-line-bg-bpt-disabled: rgba(166, 218, 149, 0.3); /*green*/
   qproperty-line-bg-bpt-unavailable: ${color-overlay0};
   qproperty-graph-bg-top: ${color-crust};
   qproperty-graph-bg-bottom: ${color-crust};
@@ -808,7 +806,7 @@ CustomIDAMemo {
   qproperty-graph-edge-current: ${color-text};
   qproperty-line-fg-patched-bytes: ${color-mauve};
   qproperty-line-fg-unsaved-changes: ${color-teal};
-  qproperty-line-bg-highlight: rgba(220, 138, 120, 0.5); /*rosewater*/
+  qproperty-line-bg-highlight: rgba(238, 153, 160, 0.19); /*rosewater*/
   qproperty-line-bg-hint: ${color-mauve};
 }
 CustomIDAMemo[debugging="true"],

--- a/catppuccin-mocha/theme.css
+++ b/catppuccin-mocha/theme.css
@@ -638,7 +638,6 @@ navband_t
     qproperty-extern : ${color-pink};
     qproperty-lumina-function : ${color-green};
 
-    /* same colors as above but lightness turned up by 5% */
     qproperty-hl-lib-function : rgb(159, 226, 239);
     qproperty-hl-function : rgb(251, 195, 159);
     qproperty-hl-code : rgb(251, 242, 240);
@@ -665,7 +664,6 @@ navband_t[os-dark-theme="true"]
     qproperty-extern : ${color-pink};
     qproperty-lumina-function : ${color-green};
 
-    /* same colors as above but lightness turned up by 5% */
     qproperty-hl-lib-function : rgb(159, 226, 239);
     qproperty-hl-function : rgb(251, 195, 159);
     qproperty-hl-code : rgb(251, 242, 240);
@@ -737,7 +735,7 @@ TextEdit {
 /* main color scheme */
 CustomIDAMemo {
   /* current line background overlay */
-  qproperty-line-bgovl-current-line: rgba(220, 138, 120, 0.25); /*rosewater*/
+  qproperty-line-bgovl-current-line: rgba(220, 138, 120, 0.1); /*rosewater*/
   qproperty-line-fg-default: ${color-overlay2};
   qproperty-line-fg-regular-comment: ${color-pink};
   qproperty-line-fg-repeatable-comment: ${color-mauve};
@@ -788,8 +786,8 @@ CustomIDAMemo {
   qproperty-line-pfx-lumina: ${color-green};
   /*qproperty-line-pfx-current-item: ${color-sapphire};*/
   qproperty-line-pfx-current-line: ${color-peach};
-  qproperty-line-bg-bpt-enabled: ${color-teal};
-  qproperty-line-bg-bpt-disabled: ${color-text};
+  qproperty-line-bg-bpt-enabled: rgba(243, 139, 168, 0.3); /*red*/
+  qproperty-line-bg-bpt-disabled: rgba(166, 227, 161, 0.3); /*green*/
   qproperty-line-bg-bpt-unavailable: ${color-overlay0};
   qproperty-graph-bg-top: ${color-crust};
   qproperty-graph-bg-bottom: ${color-crust};
@@ -808,7 +806,7 @@ CustomIDAMemo {
   qproperty-graph-edge-current: ${color-text};
   qproperty-line-fg-patched-bytes: ${color-mauve};
   qproperty-line-fg-unsaved-changes: ${color-teal};
-  qproperty-line-bg-highlight: rgba(220, 138, 120, 0.25); /*rosewater*/
+  qproperty-line-bg-highlight: rgba(220, 138, 120, 0.19); /*rosewater*/
   qproperty-line-bg-hint: ${color-mauve};
 }
 CustomIDAMemo[debugging="true"],


### PR DESCRIPTION
### Info
This pull request addresses the following, discussed in issue #3 
* Readability issues for lines with breakpoints
* Readability issues for bg highlighting for darker text

### Properties Changed
* *qproperty-line-bgovl-current-line* - now uses 10% transparency
* *qproperty-line-bg-highlight* - now uses 19% transparency
* qproperty-line-bg-bpt-enabled* - now uses `color-red` with 30% transparency
* *qproperty-line-bg-bpt-disabled* - now uses `color-green` with 30% transparency

### Screenshots of changes
#### Selection background highlighting:
![](https://i.invalid.gg/ida64_sYXwROvOXO.png)
#### Breakpoint background highlighting:
![](https://i.invalid.gg/ida64_Dhthff0V4D.png)